### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+**/.DS_Store


### PR DESCRIPTION
node_modules create paths too long for Windows to accept clones with. After adding the .gitignore and pushing again from Unix, Windows users will be able to clone the repo.
